### PR TITLE
Fix for PHP 7 issue (#30)

### DIFF
--- a/lib/PHPInsight/Sentiment.php
+++ b/lib/PHPInsight/Sentiment.php
@@ -104,9 +104,9 @@ class Sentiment {
 	 * @var array
 	 */
 	private $prior = array(
-		'pos' => 0.333333333333,
-		'neg' => 0.333333333333,
-		'neu' => 0.333333333334
+		'pos' => 0.333,
+		'neg' => 0.333,
+		'neu' => 0.334,
 	);
 
 	/**


### PR DESCRIPTION
The issue is that the rounding to 3 dp ignores the 4 placed many decimal
points down.

This puts the 4 within the 3dp, and allows neutral to be chosen again